### PR TITLE
remove unnecessary boost dependency

### DIFF
--- a/ros2/package.xml
+++ b/ros2/package.xml
@@ -13,7 +13,6 @@
 
   <buildtool_depend>cmake</buildtool_depend>
 
-  <depend>boost</depend>
   <depend>console_bridge</depend>
   <depend>tinyxml</depend>
 


### PR DESCRIPTION
As we ship our own urdfdom_headers specifically to use the boost-free version, the dependency should be removed from the package.xml