### PR TITLE
Remove the package.xml application for rolling 

### DIFF
--- a/tracks.yaml
+++ b/tracks.yaml
@@ -340,7 +340,7 @@ tracks:
     devel_branch: master
     last_version: 1.1.1
     name: urdfdom_headers
-    patches: foxy
+    patches: null
     release_inc: '2'
     release_repo_url: https://github.com/ros2-gbp/urdfdom_headers-release.git
     release_tag: :{version}

--- a/tracks.yaml
+++ b/tracks.yaml
@@ -337,7 +337,7 @@ tracks:
       :{release_inc} --os-name fedora
     - git-bloom-generate -y rosrpm --prefix release/:{ros_distro} :{ros_distro} -i
       :{release_inc} --os-name rhel
-    devel_branch: master
+    devel_branch: rolling
     last_version: 1.1.1
     name: urdfdom_headers
     patches: null


### PR DESCRIPTION
There is a PR open to add `package.xml` to the rolling branch of `urdfdom_headers`. 
https://github.com/ros/urdfdom_headers/issues/82

This PR disables the patching stage of `urdfdom_headers-release` for the `rolling` branch to avoid a CI failure.

